### PR TITLE
makes TIMEOUT_KEEP_ALIVE larger

### DIFF
--- a/ochat/serving/openai_api_server.py
+++ b/ochat/serving/openai_api_server.py
@@ -33,7 +33,7 @@ from ochat.serving import openai_api_protocol, async_tokenizer
 from transformers.utils.hub import cached_file
 
 
-TIMEOUT_KEEP_ALIVE = 5  # seconds
+TIMEOUT_KEEP_ALIVE = 20 # seconds
 
 
 @dataclass


### PR DESCRIPTION
As we have the requests.exceptions.ChunkedEncodingError, the idea is to increase TIMOUT_KEEP_ALIVE parameter of uvicorn